### PR TITLE
Fix memory leak problem on MonadRec foldFree

### DIFF
--- a/src/Data/CatList.purs
+++ b/src/Data/CatList.purs
@@ -69,9 +69,7 @@ length = Foldable.length
 -- |
 -- | Running time: `O(1)`
 append :: forall a. CatList a -> CatList a -> CatList a
-append as CatNil = as
-append CatNil as = as
-append as bs = link as bs
+append = link
 
 -- | Append an element to the beginning of the catenable list, creating a new
 -- | catenable list.

--- a/src/Data/CatList.purs
+++ b/src/Data/CatList.purs
@@ -110,6 +110,7 @@ uncons (CatCons a q) = Just (Tuple a (if Q.null q then CatNil else (foldr link C
 -- | Running time: `O(1)`
 link :: forall a. CatList a -> CatList a -> CatList a
 link CatNil cat = cat
+link cat CatNil = cat
 link (CatCons a q) cat = CatCons a (Q.snoc q cat)
 
 -- | Tail recursive version of foldr on `CatList`.


### PR DESCRIPTION
This simple infinite loop on Free causes memory leak.

```purescript
main :: Effect Unit
main = foldFree identity $ do
  void <<< forever $ do
    liftF $ pure unit
  liftF $ log "next step, not reached"
```

`L.Cons CatNil (L.Cons CatNil (L.Cons CatNil ...` in CatQueue.

Fixed it!